### PR TITLE
docs: improve markdown syntax

### DIFF
--- a/session1/plugin-development-intro/lua-cheatsheet/README.md
+++ b/session1/plugin-development-intro/lua-cheatsheet/README.md
@@ -71,10 +71,18 @@ elseif condition then
 else
   print("no")
 end
-Variables
+```
+
+## Variables
+
+```lua
 local x = 2
 two, four = 2, 4
-Functions
+```
+
+## Functions
+
+```lua
 function myFunction()
   return 1
 end
@@ -100,7 +108,11 @@ function doAction(action, ...)
 end
 
 doAction('write', "Shirley", "Abed")
-Lookups
+```
+
+## Lookups
+
+```lua
 mytable = { x = 2, y = function() .. end }
 
 -- The same:
@@ -116,7 +128,11 @@ mytable:y(a, b)
 
 function X:y(z) .. end
 function X.y(self, z) .. end
-Metatables
+```
+
+## Metatables
+
+```lua
 mt = {}
 
 -- A metatable is simply a table with functions in it.


### PR DESCRIPTION
I made a minor change because I thought it was inappropriate to be included in a single code block.